### PR TITLE
keymap: add Vial keys to tune scroll curve

### DIFF
--- a/qmk_firmware/keyboards/split_ortho4x6/keymaps/vial/tb.h
+++ b/qmk_firmware/keyboards/split_ortho4x6/keymaps/vial/tb.h
@@ -21,4 +21,10 @@ enum tb_keycodes {
     TB_R_ROT_L15,
     TB_SCR_TOG,   // 左のみスクロール/カーソル切替
     TB_SCR_DIV,   // スクロール速度（分割）を変更（グローバル）
+    // スクロールカーブ調整（グローバル）
+    TB_SC_GAIN_UP,
+    TB_SC_GAIN_DN,
+    TB_SC_GAMMA_UP,
+    TB_SC_GAMMA_DN,
+    TB_SC_RESET,
 };

--- a/qmk_firmware/keyboards/split_ortho4x6/keymaps/vial/vial.json
+++ b/qmk_firmware/keyboards/split_ortho4x6/keymaps/vial/vial.json
@@ -140,6 +140,11 @@
         {"name": "Trackball Right", "title": "右: 回転+15°",            "shortName": "R ROT+"},
         {"name": "Trackball Right", "title": "右: 回転-15°",            "shortName": "R ROT-"},
         {"name": "Trackball Mode",  "title": "スクロール/カーソル切替", "shortName": "SCR TOG"},
-        {"name": "Trackball Mode",  "title": "スクロール速度",          "shortName": "SCR DIV"}
+        {"name": "Trackball Mode",  "title": "スクロール速度",          "shortName": "SCR DIV"},
+        {"name": "Scroll Curve",    "title": "スクロール: sc_gain を増加 (+0.10)",  "shortName": "GAIN+"},
+        {"name": "Scroll Curve",    "title": "スクロール: sc_gain を減少 (-0.10)",  "shortName": "GAIN-"},
+        {"name": "Scroll Curve",    "title": "スクロール: sc_gamma を増加 (+0.05)", "shortName": "GAMMA+"},
+        {"name": "Scroll Curve",    "title": "スクロール: sc_gamma を減少 (-0.05)", "shortName": "GAMMA-"},
+        {"name": "Scroll Curve",    "title": "スクロール: カーブ設定を初期化",      "shortName": "RESET"}
     ]
 }


### PR DESCRIPTION
- Add TB_SC_GAIN_UP/DN (+0.10) and TB_SC_GAMMA_UP/DN (+0.05)
- Add TB_SC_RESET to restore defaults (gain=1.25, gamma=0.80)
- Persist indices in eeconfig; clamp to valid ranges
- Expose 5 keys in vial.json (Scroll Curve)
- Keep scroll curve from smoothed raw (pre-dyn/CPI)